### PR TITLE
Fixed heightNormalizer when all data points are same

### DIFF
--- a/lib/src/sparkline.dart
+++ b/lib/src/sparkline.dart
@@ -296,7 +296,7 @@ class _SparklinePainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     double width = size.width - lineWidth;
     final double height = size.height - lineWidth;
-    final double heightNormalizer = height / (_max - _min);
+    final double heightNormalizer = height / (_max == _min ? height : _max - _min);
 
     final Path path = new Path();
     final List<Offset> points = <Offset>[];


### PR DESCRIPTION
Fixed heightNormalizer when all data points are same, which results in both `min` and `max` being same. Hence when both `max` and `min` are, same using the `height` would work fine.